### PR TITLE
Resolved opencv dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM tensorflow/tensorflow:1.15.0-py3
 
-RUN apt-get update && apt-get install -y libsm6 libxext6 libxrender-dev libtiff5-dev git
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
+RUN apt-get install -y python3-opencv
+RUN apt-get install -y libtiff5-dev git
 
-RUN pip install cython scikit-image==0.14.2 matplotlib tifffile==2020.2.16 scipy==1.1.0 opencv-python==4.1.1
+RUN pip install cython scikit-image==0.14.2 matplotlib tifffile==2020.2.16 scipy==1.1.0 opencv-python==4.3.0.36
 
 RUN pip install git+https://github.com/FZJ-INM1-BDA/pytiff.git@0701f28e5862c26024e8daa34201005b16db4c8f
 


### PR DESCRIPTION
A recent change in shared library dependencies caused a required OpenGL library to be omitted from installation during `docker build`.

1. Switched to a [more robust specification of opencv dependencies](https://stackoverflow.com/a/66473309/300187).
2. Added special handling of `tzdata`, due to [a known issue](https://serverfault.com/questions/949991/how-to-install-tzdata-on-a-ubuntu-docker-image).
3. Confirmed locally that the following works:
```
docker build -t test .
docker run --rm test python -c "import cv2"
```