### PR TITLE
Add imagecodecs to Dockerfile pip install line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,15 @@ RUN apt-get update \
 
 RUN pip install \
     --no-cache-dir \
-    cython scikit-image matplotlib tifffile scipy opencv-python zarr tensorflow tf_keras
+    cython \
+    imagecodecs \
+    matplotlib \
+    opencv-python \
+    scikit-image \
+    scipy \
+    tensorflow \
+    tf_keras \
+    tifffile \
+    zarr
 
 COPY . /app


### PR DESCRIPTION
This is needed to support LZW-compressed input tiffs.